### PR TITLE
add output id of azurerm_api_management_product

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -2,3 +2,8 @@ output "product_id" {
   value       = azurerm_api_management_product.product.product_id
   description = "ID of the product"
 }
+
+output "id" {
+  value       = azurerm_api_management_product.product.id
+  description = "The ID of the API Management Product"
+}


### PR DESCRIPTION
### Change description ###
add output id of azurerm_api_management_product

Added additional id reference, product_id is used in some places:
https://github.com/search?p=2&q=org%3Ahmcts+product_id&type=Code

id needed for this to reference module rather than additional data
https://github.com/hmcts/ccpay-refunds-app/blob/demo/infrastructure/refund_lists.tf#L79

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
